### PR TITLE
Update README.adoc for Zig 0.11 release

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,4 +6,4 @@ SVD is copied from https://github.com/esp-rs/esp-pacs
 
 == What version of Zig to use
 
-Right now we are following https://ziglang.org/download/[master], but once 0.11.0 is released, we will be switching to the latest stable version of Zig.
+0.11.0


### PR DESCRIPTION
Zig 0.11 was released.
I guess it makes sense to update the readme.
Looking at microzig, it looks like 0.11 is the supported version.